### PR TITLE
Expose the typographic bounds as a function within the CoreText Run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Cargo.lock
 target/
+.idea
 

--- a/core-text/src/run.rs
+++ b/core-text/src/run.rs
@@ -91,7 +91,11 @@ impl CTRun {
         let mut descent = 0.0;
         let mut leading = 0.0;
         unsafe {
-            let width = CTRunGetTypographicBounds(self.as_concrete_TypeRef(), &mut ascent, &mut descent, &mut leading);
+            let range =  CFRange {
+        location: 0,
+        length: 0,
+    };
+            let width = CTRunGetTypographicBounds(self.as_concrete_TypeRef(), range, &mut ascent, &mut descent, &mut leading);
             TypographicBounds { width, ascent, descent, leading }
         }
     }
@@ -163,5 +167,5 @@ extern {
     fn CTRunGetGlyphsPtr(run: CTRunRef) -> *const CGGlyph;
     fn CTRunGetGlyphs(run: CTRunRef, range: CFRange, buffer: *const CGGlyph);
 
-    fn CTRunGetTypographicBounds(line: CTRunRef, ascent: *mut CGFloat, descent: *mut CGFloat, leading: *mut CGFloat) -> CGFloat;
+    fn CTRunGetTypographicBounds(line: CTRunRef, range: CFRange, ascent: *mut CGFloat, descent: *mut CGFloat, leading: *mut CGFloat) -> CGFloat;
 }

--- a/core-text/src/run.rs
+++ b/core-text/src/run.rs
@@ -15,6 +15,9 @@ use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::CFString;
 use core_graphics::font::CGGlyph;
 use core_graphics::geometry::CGPoint;
+use core_graphics::base::{CGFloat};
+
+use crate::line::TypographicBounds;
 
 #[repr(C)]
 pub struct __CTRun(c_void);
@@ -80,6 +83,16 @@ impl CTRun {
                 vec.set_len(count as usize);
                 Cow::from(vec)
             }
+        }
+    }
+
+    pub fn get_typographic_bounds(&self) -> TypographicBounds {
+        let mut ascent = 0.0;
+        let mut descent = 0.0;
+        let mut leading = 0.0;
+        unsafe {
+            let width = CTRunGetTypographicBounds(self.as_concrete_TypeRef(), &mut ascent, &mut descent, &mut leading);
+            TypographicBounds { width, ascent, descent, leading }
         }
     }
 
@@ -149,4 +162,6 @@ extern {
     fn CTRunGetStringIndices(run: CTRunRef, range: CFRange, buffer: *const CFIndex);
     fn CTRunGetGlyphsPtr(run: CTRunRef) -> *const CGGlyph;
     fn CTRunGetGlyphs(run: CTRunRef, range: CFRange, buffer: *const CGGlyph);
+
+    fn CTRunGetTypographicBounds(line: CTRunRef, ascent: *mut CGFloat, descent: *mut CGFloat, leading: *mut CGFloat) -> CGFloat;
 }


### PR DESCRIPTION
As part of workflows, we need to know the bounds for a CoreText run via [this](https://developer.apple.com/documentation/coretext/1510569-ctrungettypographicbounds ) function.

For simplicity--expose it directly on the `Run` object to make it simpler to interact with inside Warp.