### PR TITLE
Fix Ventura Crash

### DIFF
--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -20,6 +20,7 @@ use core_graphics::base::CGFloat;
 
 use std::os::raw::c_void;
 use std::path::PathBuf;
+use core_foundation::boolean::CFBoolean;
 
 /*
 * CTFontTraits.h
@@ -132,7 +133,19 @@ trait TraitAccessorPrivate {
 impl TraitAccessorPrivate for CTFontTraits {
     fn extract_number_for_key(&self, key: CFStringRef) -> CFNumber {
         let cftype = self.get(key);
-        cftype.downcast::<CFNumber>().unwrap()
+        let number = cftype.downcast::<CFNumber>();
+        match number {
+            Some(number) => number,
+            None => {
+                // The value was not able to be converted to a CFNumber, this violates the Core
+                // Foundation's docs (see https://developer.apple.com/documentation/coretext/kctfontsymbolictrait)
+                // but can occur in practice with certain fonts in MacOS 13 (Ventura). When this
+                // does occur in Ventura, the value returned is always a CFBoolean, so we attempt to
+                // convert into a boolean and create a number from there.
+                let value_as_bool = bool::from(cftype.downcast::<CFBoolean>().expect("Should be able to convert value into CFBoolean"));
+                CFNumber::from(value_as_bool as i32)
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Fixes WAR-3757

At a high level the issue that's causing this crash is that reading from the [font traits](https://developer.apple.com/documentation/coretext/kctfontsymbolictrait) `CFDictionary` in Core Text doesn't always return a value that matches the `CFNumber`  [`CFTypeID`](https://developer.apple.com/documentation/corefoundation/cftypeid) (it returns a `CFBoolean` that is always `false` instead).

Confirmed in vanilla Objective-C the exact same behavior. As a simple fix, try to downcast into a `CFBoolean` if downcasting into a `CFNumber` fails and then recreate a `CFNumber` from that `CFBoolean`.

Verified locally that Warp fully works on Ventura--I've used it as my day to day terminal for the past day with no issues.,


Note will also try to fix this upstream and merge the two versions of core-foundation-rs as a followup